### PR TITLE
 (Resolves #226) Change scipy.ndimage.imread to imageio.imread in autokeras.utils

### DIFF
--- a/autokeras/utils.py
+++ b/autokeras/utils.py
@@ -5,9 +5,9 @@ import sys
 import tempfile
 import zipfile
 
+import imageio
 import requests
 import torch
-from scipy import ndimage
 
 from autokeras.constant import Constant
 
@@ -195,5 +195,5 @@ def read_csv_file(csv_file_path):
 
 
 def read_image(img_path):
-    img = ndimage.imread(fname=img_path)
+    img = imageio.imread(uri=img_path)
     return img

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ scikit-learn==0.19.1
 keras==2.2.2
 tqdm==4.25.0
 tensorflow==1.10.0
+imageio
 pytest
 pytest-cov
 coverage


### PR DESCRIPTION
This pull request resolves #226.

The pull request is ready to be merged.

The details of the pull request:
scipy.ndimage.imread is deprecated and hence it is replaced by imageio.imread. 'requirements.txt' is updated with imageio.
