### PR TITLE
[MRG]solve text preprocessor error when no gpu

### DIFF
--- a/autokeras/text/text_preprocessor.py
+++ b/autokeras/text/text_preprocessor.py
@@ -79,7 +79,7 @@ def read_embedding_index(extract_path):
         embedding_index: Dictionary contains word with pre trained index.
     """
     embedding_index = {}
-    f = open(os.path.join(extract_path, Constant.PRE_TRAIN_FILE_NAME))
+    f = open(os.path.join(extract_path, Constant.PRE_TRAIN_FILE_NAME), encoding="utf-8")
     for line in f:
         values = line.split()
         word = values[0]
@@ -139,12 +139,15 @@ def processing(path, word_index, input_length, x_train):
     embedding_matrix = load_pretrain(path=path, word_index=word_index)
 
     # Get the first available GPU
-    device_id_list = GPUtil.getFirstAvailable()
-    device_id = device_id_list[0]  # grab first element from list
+    try:
+        device_id_list = GPUtil.getFirstAvailable()
+        device_id = device_id_list[0]  # grab first element from list
+        # Set CUDA_VISIBLE_DEVICES to mask out all other GPUs than the first available device id
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(device_id)
+        device = '/gpu:0'
+    except:
+        device = '/cpu:0'
 
-    # Set CUDA_VISIBLE_DEVICES to mask out all other GPUs than the first available device id
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(device_id)
-    device = '/gpu:0'
     with tf.device(device):
         from keras import Input, Model
         from keras import backend

--- a/examples/text_cnn/text.py
+++ b/examples/text_cnn/text.py
@@ -27,4 +27,4 @@ if __name__ == '__main__':
     file_path = "labeledTrainData.tsv"
     x_train, y_train = read_csv(file_path=file_path)
     clf = TextClassifier(verbose=True)
-    clf.fit(x=x_train, y=y_train, batch_size=10, time_limit=12 * 60 * 60)
+    clf.fit(x=x_train, y=y_train, time_limit=12 * 60 * 60)

--- a/tests/text/test_text_preprocessor.py
+++ b/tests/text/test_text_preprocessor.py
@@ -57,7 +57,7 @@ def test_load_pretrain(_, _1):
 
 @patch('autokeras.text.text_preprocessor.load_pretrain', side_effect=mock_load_pretrain)
 def test_processing(_):
-    results = [[0], RuntimeError("Foo")]
+    results = [[0], Exception("Foo")]
     with patch('autokeras.text.text_preprocessor.GPUtil.getFirstAvailable', side_effect=results):
         train_x = np.full((1, 2), 1)
         train_x = processing(TEST_TEMP_DIR, word_index, 2, train_x)

--- a/tests/text/test_text_preprocessor.py
+++ b/tests/text/test_text_preprocessor.py
@@ -55,12 +55,16 @@ def test_load_pretrain(_, _1):
     assert (embedding_matrix[1] == embedding_index.get("bar")).all()
 
 
-@patch('autokeras.text.text_preprocessor.GPUtil.getFirstAvailable', return_value=[0])
 @patch('autokeras.text.text_preprocessor.load_pretrain', side_effect=mock_load_pretrain)
-def test_processing(_, _1):
-    train_x = np.full((1, 2), 1)
-    train_x = processing(TEST_TEMP_DIR, word_index, 2, train_x)
-    assert np.allclose(train_x[0][0], embedding_matrix[1])
+def test_processing(_):
+    results = [[0], RuntimeError("Foo")]
+    with patch('autokeras.text.text_preprocessor.GPUtil.getFirstAvailable', side_effect=results):
+        train_x = np.full((1, 2), 1)
+        train_x = processing(TEST_TEMP_DIR, word_index, 2, train_x)
+        assert np.allclose(train_x[0][0], embedding_matrix[1])
+        train_x = np.full((1, 2), 1)
+        train_x = processing(TEST_TEMP_DIR, word_index, 2, train_x)
+        assert np.allclose(train_x[0][0], embedding_matrix[1])
 
 
 def test_tokenlize_text():


### PR DESCRIPTION
This pull request resolves #387.

The pull request is ready to be merged.

The details of the pull request:
* GPUtil.getFirstAvailable() will throw an exception if there's no gpu. This exception comes from Nvidia-smi. Thus, it cannot be caught as RuntimeError.
* Add one more mock in the test for mocking the exception. 
