### PR TITLE
fix the order of y_true and y_pred parameters

### DIFF
--- a/autokeras/nn/metric.py
+++ b/autokeras/nn/metric.py
@@ -34,7 +34,7 @@ class Accuracy(Metric):
 
     @classmethod
     def evaluate(cls, prediction, target):
-        return accuracy_score(prediction, target)
+        return accuracy_score(target, prediction)
 
 
 class MSE(Metric):
@@ -48,4 +48,4 @@ class MSE(Metric):
 
     @classmethod
     def evaluate(cls, prediction, target):
-        return mean_squared_error(prediction, target)
+        return mean_squared_error(target, prediction)

--- a/autokeras/supervised.py
+++ b/autokeras/supervised.py
@@ -206,7 +206,7 @@ class DeepSupervised(Supervised):
     def evaluate(self, x_test, y_test):
         """Return the accuracy score between predict value and `y_test`."""
         y_predict = self.predict(x_test)
-        return self.metric().evaluate(y_test, y_predict)
+        return self.metric().evaluate(y_predict, y_test)
 
 
 class PortableClass(ABC):
@@ -332,4 +332,4 @@ class PortableDeepSupervised(PortableClass):
     def evaluate(self, x_test, y_test):
         """Return the accuracy score between predict value and `y_test`."""
         y_predict = self.predict(x_test)
-        return self.metric().evaluate(y_test, y_predict)
+        return self.metric().evaluate(y_predict, y_test)


### PR DESCRIPTION
Hello, I have been reading and applying autokeras. Thank you for your sharing. At the meanwhile, I found the following bug.
The call of skleran.metrics.* should be (y_true, y_pred).
The call of autokeras.nn.metric.evaluate maybe (y_pred, y_true).
