### PR TITLE
fix the assignment of augment

### DIFF
--- a/autokeras/preprocessor.py
+++ b/autokeras/preprocessor.py
@@ -182,7 +182,8 @@ class ImageDataTransformer(DataTransformer):
         self.std = np.std(data, axis=(0, 1, 2), keepdims=True).flatten()
         if augment is None:
             self.augment = Constant.DATA_AUGMENTATION
-        self.augment = augment
+        else:
+            self.augment = augment
 
     def transform_train(self, data, targets=None, batch_size=None):
         """ Transform the training data, perform random cropping data augmentation and basic random flip augmentation.


### PR DESCRIPTION
Hello, the assignment of augment is incorrect when the augment parameter is equal to `None`. Just a little bug :stuck_out_tongue_winking_eye:. Although nothing unexpected appear here due to having been checking before in other class. If others use this class directly, there will be something wrong.

By the way, I found the `fit(x, y)` function need to read all data in memory. This is unfriendly for large dataset. So I am ready to solve the problem. The main idea is to make the parameter `x` support string data type which contains all paths of images. Can I? 
