### PR TITLE
Update layers.py

### DIFF
--- a/autokeras/nn/layers.py
+++ b/autokeras/nn/layers.py
@@ -174,7 +174,7 @@ class StubConv(StubWeightBiasLayer):
         return tuple(ret)
 
     def size(self):
-        return (self.filters * self.kernel_size * self.kernel_size + 1) * self.input_channel
+        return (self.input_channel * self.kernel_size * self.kernel_size + 1) * self.filters
 
     @abstractmethod
     def to_real_layer(self):

--- a/autokeras/nn/layers.py
+++ b/autokeras/nn/layers.py
@@ -174,7 +174,7 @@ class StubConv(StubWeightBiasLayer):
         return tuple(ret)
 
     def size(self):
-        return self.filters * self.kernel_size * self.kernel_size + self.filters
+        return (self.filters * self.kernel_size * self.kernel_size + 1) * self.input_channel
 
     @abstractmethod
     def to_real_layer(self):

--- a/tests/nn/test_graph.py
+++ b/tests/nn/test_graph.py
@@ -165,7 +165,7 @@ def test_node_consistency():
 
 def test_graph_size():
     graph = CnnGenerator(10, (32, 32, 3)).generate()
-    assert graph.size() == 7254
+    assert graph.size() == 80982
 
 
 def test_long_transform():


### PR DESCRIPTION
Original Conv2d layer parameter calculation is wrong. Please refer to [this](https://medium.com/@iamvarman/how-to-calculate-the-number-of-parameters-in-the-cnn-5bd55364d7ca).

The pull request is ready to be merged.

The details of the pull request:
```diff
- return self.filters * self.kernel_size * self.kernel_size + self.filters
+ return (self.input_channel * self.kernel_size * self.kernel_size + 1) * self.filters
```
