### PR TITLE
[MRG] 'read_images' function modifications to allow 'img_file_names' to be an optional argument : Resolves #585

### DIFF
--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -35,8 +35,7 @@ def read_images(images_dir_path, parallel=True, img_file_names = None):
     Args:
         images_dir_path: Path to the directory containing images.
         parallel: (Default: True) Run _image_to_array will use multiprocessing.
-        img_file_names: (Default: None) List of strings representing image file names. 
-        
+        img_file_names: (Default: None) List of strings representing image file names.
     Returns:
         x_train: a list of numpy.ndarrays containing the loaded images.
     """

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -40,7 +40,7 @@ def read_images(images_dir_path, parallel=True, img_file_names = None):
         x_train: a list of numpy.ndarrays containing the loaded images.
     """
     if img_file_names is None:
-        img_file_names = [img_file for img_file in os.listdir(images_dir_path) if  imghdr.what(os.path.join(images_dir_path, img_file)) is not None]
+        img_file_names = [img_file for img_file in os.listdir(images_dir_path) if (imghdr.what(os.path.join(images_dir_path, img_file)) is not None)]
         
     img_paths = [os.path.join(images_dir_path, img_file)
                  for img_file in img_file_names]

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -31,8 +31,7 @@ def _image_to_array(img_path):
 
 
 def read_images(images_dir_path, parallel=True, img_file_names = None):
-    """Read the images from the path and return their numpy.ndarray instances.
-    If no image file names are specified, read all image files present in the directory images_dir_path
+    """Read the images from the path and return their numpy.ndarray instances. If no image file names are specified, read all image files present in the directory images_dir_path
     Args:
         images_dir_path: Path to the directory containing images.
         parallel: (Default: True) Run _image_to_array will use multiprocessing.

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -32,7 +32,7 @@ def _image_to_array(img_path):
 
 def read_images(images_dir_path, parallel=True, img_file_names = None):
     """Read the images from the path and return their numpy.ndarray instances.
-    If not image file names are specified, read all image files present in the directory images_dir_path
+    If no image file names are specified, read all image files present in the directory images_dir_path
     Args:
         images_dir_path: Path to the directory containing images.
         parallel: (Default: True) Run _image_to_array will use multiprocessing.

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -2,6 +2,7 @@ import os
 from abc import ABC
 import numpy as np
 from multiprocessing import Pool, cpu_count
+import imghdr
 
 from autokeras.constant import Constant
 from autokeras.nn.loss_function import classification_loss, regression_loss
@@ -29,17 +30,20 @@ def _image_to_array(img_path):
         raise ValueError("%s image does not exist" % img_path)
 
 
-def read_images(img_file_names, images_dir_path, parallel=True):
+def read_images(images_dir_path, parallel=True, img_file_names = None):
     """Read the images from the path and return their numpy.ndarray instances.
-
+    If not image file names are specified, read all image files present in the directory images_dir_path
     Args:
-        img_file_names: List of strings representing image file names. # DEVELOPERS THERE'S PROBABLY A WAY TO MAKE THIS PARAM. OPTIONAL
         images_dir_path: Path to the directory containing images.
         parallel: (Default: True) Run _image_to_array will use multiprocessing.
+        img_file_names: (Default: None) List of strings representing image file names. 
         
     Returns:
         x_train: a list of numpy.ndarrays containing the loaded images.
     """
+    if img_file_names is None:
+        img_file_names = [img_file for img_file in os.listdir(images_dir_path) if  imghdr.what(os.path.join(images_dir_path, img_file)) is not None]
+        
     img_paths = [os.path.join(images_dir_path, img_file)
                  for img_file in img_file_names]
 
@@ -54,7 +58,6 @@ def read_images(img_file_names, images_dir_path, parallel=True):
     else:
         raise ValueError("Directory containing images does not exist")
     return np.asanyarray(x_train)
-
 
 def load_image_dataset(csv_file_path, images_path, parallel=True):
     """Load images from their files and load their labels from a csv file.

--- a/autokeras/image/image_supervised.py
+++ b/autokeras/image/image_supervised.py
@@ -29,19 +29,16 @@ def _image_to_array(img_path):
     else:
         raise ValueError("%s image does not exist" % img_path)
 
-
-def read_images(images_dir_path, parallel=True, img_file_names = None):
-    """Read the images from the path and return their numpy.ndarray instances. If no image file names are specified, read all image files present in the directory images_dir_path
+def read_images(img_file_names, images_dir_path, parallel=True):
+    """Read the images from the path and return their numpy.ndarray instances.
     Args:
+        img_file_names: List of strings representing image file names. # DEVELOPERS THERE'S PROBABLY A WAY TO MAKE THIS PARAM. OPTIONAL
         images_dir_path: Path to the directory containing images.
         parallel: (Default: True) Run _image_to_array will use multiprocessing.
-        img_file_names: (Default: None) List of strings representing image file names.
+        
     Returns:
         x_train: a list of numpy.ndarrays containing the loaded images.
     """
-    if img_file_names is None:
-        img_file_names = [img_file for img_file in os.listdir(images_dir_path) if (imghdr.what(os.path.join(images_dir_path, img_file)) is not None)]
-        
     img_paths = [os.path.join(images_dir_path, img_file)
                  for img_file in img_file_names]
 
@@ -56,6 +53,19 @@ def read_images(images_dir_path, parallel=True, img_file_names = None):
     else:
         raise ValueError("Directory containing images does not exist")
     return np.asanyarray(x_train)
+
+def read_images_from_directory(images_dir_path, parallel=True, img_file_names = None):
+    """Read the images from the path and return their numpy.ndarray instances. If no image file names are specified, read all image files present in the directory images_dir_path
+    Args:
+        images_dir_path: Path to the directory containing images.
+        parallel: (Default: True) Run _image_to_array will use multiprocessing.
+        img_file_names: (Default: None) List of strings representing image file names.
+    Returns:
+        x_train: a list of numpy.ndarrays containing the loaded images.
+    """
+    if img_file_names is None:
+        img_file_names = [img_file for img_file in os.listdir(images_dir_path) if (imghdr.what(os.path.join(images_dir_path, img_file)) is not None)]
+    return read_images(img_file_names, images_dir_path, parallel)
 
 def load_image_dataset(csv_file_path, images_path, parallel=True):
     """Load images from their files and load their labels from a csv file.

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -182,6 +182,7 @@ def test_fit_predict_regression(_, _1):
     clean_dir(TEST_TEMP_DIR)
     
 def test_read_images_from_directory():
-    x_train = read_images_from_directory(images_dir_path=os.path.join(path, "images_test/Color_images"))
-    assert len(results) == 15
+    color_img_path = os.path.join(path, "images_test/Color_images")
+    x_train = read_images_from_directory(images_dir_path = color_img_path)
+    assert len(results) == len(os.listdir(color_img_path))
     clean_dir(os.path.join(path, "temp"))

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -180,3 +180,8 @@ def test_fit_predict_regression(_, _1):
     results = clf.predict(train_x)
     assert len(results) == len(train_x)
     clean_dir(TEST_TEMP_DIR)
+    
+def test_read_images_from_directory():
+    x_train = read_images_from_directory(images_dir_path=os.path.join(path, "images_test/Color_images"))
+    assert len(results) == 15
+    clean_dir(os.path.join(path, "temp"))

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -4,6 +4,7 @@ import pytest
 
 from autokeras.image.image_supervised import *
 from tests.common import clean_dir, MockProcess, simple_transform, mock_train, TEST_TEMP_DIR
+import os
 
 
 def test_train_x_array_exception():
@@ -183,6 +184,7 @@ def test_fit_predict_regression(_, _1):
     
 def test_read_images_from_directory():
     color_img_path = os.path.join(path, "images_test/Color_images")
+    path = 'tests/resources'
     x_train = read_images_from_directory(images_dir_path = color_img_path)
-    assert len(results) == len(os.listdir(color_img_path))
+    assert len(x_train) == len(os.listdir(color_img_path))
     clean_dir(os.path.join(path, "temp"))

--- a/tests/image/test_image_supervised.py
+++ b/tests/image/test_image_supervised.py
@@ -183,8 +183,8 @@ def test_fit_predict_regression(_, _1):
     clean_dir(TEST_TEMP_DIR)
     
 def test_read_images_from_directory():
-    color_img_path = os.path.join(path, "images_test/Color_images")
     path = 'tests/resources'
+    color_img_path = os.path.join(path, "images_test/Color_images")
     x_train = read_images_from_directory(images_dir_path = color_img_path)
     assert len(x_train) == len(os.listdir(color_img_path))
     clean_dir(os.path.join(path, "temp"))


### PR DESCRIPTION
**This pull request resolves #585** .

**The pull request is in progress.** I have yet to add an example use case, and documentation for the use case when images need to be read in for a specific task, and labels are not required to be read in.

**The details of the pull request**:

- This pull request adds support for passing only the directory name to the 'read_images_from_directory' function for supervised image models, with the list of image file names as an optional parameter. This new function read_images_from_directory() can be used by the user with only the name of the directory. It would traverse the top level of the directory to include all image files directly under this directory. It would then call the 'read_images' function with this list of file names.

- If the 'img_file_names' argument is not passed by user while calling 'read_images_from_directory', each file in the top level directly under the directory, shall be checked using the 'imghdr' module from the Python Standard library. This would help determine which of the files in the directory are image files, and would require processing.

- This feature would also be useful when a directory contains both image as well as non-image files, as then the method would internally verify and collect only the image files from the directory.

- By making 'img_file_names' an optional argument in the new function, it would be the user's choice whether to pass both the image directory as well as the image file names, or to avoid passing the file names since they can be inferred from the directory. 

- Useful when the image labels and locations are not integrated in a single csv file, so load_images() function is not used, instead read_images() has to be directly called , to obtain images.